### PR TITLE
fix: ignore mount_point changes in LXCs

### DIFF
--- a/pve/terraform/ct-300-2.tf
+++ b/pve/terraform/ct-300-2.tf
@@ -70,6 +70,6 @@ resource "proxmox_virtual_environment_container" "kube_node" {
   # }
 
   lifecycle {
-    ignore_changes = [node_name, started]
+    ignore_changes = [node_name, started, mount_point]
   }
 }


### PR DESCRIPTION
mount_points can be handled by ansible