### PR TITLE
fix(recyclarr)

### DIFF
--- a/k8s/apps/arr-apps/recyclarr/cronjob.yaml
+++ b/k8s/apps/arr-apps/recyclarr/cronjob.yaml
@@ -71,21 +71,16 @@ spec:
               medium: Memory
           - name: secret-sonarr
             secret:
-              namespace: arr-apps
               secretName: sonarr
           - name: secret-sonarr-4k
             secret:
-              namespace: arr-apps
               secretName: sonarr-4k
           - name: secret-radarr-requests
             secret:
-              namespace: arr-apps
               secretName: radarr-requests
           - name: secret-radarr-automated
             secret:
-              namespace: arr-apps
               secretName: radarr-automated
           - name: secret-radarr-4k
             secret:
-              namespace: arr-apps
               secretName: radarr-4k

--- a/k8s/apps/arr-apps/recyclarr/kustomization.yaml
+++ b/k8s/apps/arr-apps/recyclarr/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
 
 configMapGenerator:
 - name: recyclarr-config
-  behavior: merge
   options:
     disableNameSuffixHash: true
   files:


### PR DESCRIPTION
- Remove explicit secret namespaces in Kubernetes manifests
- Adjust `recyclarr` ConfigMap handling by removing the configMap merge behavior